### PR TITLE
Adjust TLS config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,6 +31,7 @@ linters-settings:
       - wrapperFunc
       - dupImport # https://github.com/go-critic/go-critic/issues/845
       - ifElseChain
+      - whyNoLint
       - octalLiteral
   funlen:
     lines: 100

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 ## 0.0.6 (November 28, 2019)
 
+BUG FIXES:
+* Connection failed when TLS was enabled since no server name was defined and InsecureSkipVerify was set to true. We are now setting to server name in the TLS config and also allowing InsecureSkipVerify to be set to false via provider setup, which results in a TLS connection without checking the certificate.
+
+```hcl
+# Configure the AD Provider
+provider "activedirectory" {
+  ...
+  use_tls  = true
+  no_cert_verify = true
+  ...
+}
+
+## 0.0.6 (November 28, 2019)
+
+NOTES:
+* We added GoReleaser to our releasing pipeline.
+
+## 0.0.6 (November 28, 2019)
+
 NOTES:
 * We added GoReleaser to our releasing pipeline.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Terraform Provider - Active Directory
 
-[![GolangCI](https://golangci.com/badges/github.com/golangci/golangci-lint.svg)](https://golangci.com)
+[![Go Report Card](https://goreportcard.com/badge/github.com/ParagonIaC/terraform-provider-activedirectory)](https://goreportcard.com/report/github.com/ParagonIaC/terraform-provider-activedirectory)
+https://goreportcard.com/report/github.com/ParagonIaC/terraform-provider-activedirectory
 [![CircleCI](https://img.shields.io/circleci/build/github/ParagonIaC/terraform-provider-activedirectory?style=flat-square&label=building)](https://circleci.com/gh/ParagonIaC/terraform-provider-activedirectory)
 [![Codecov](https://img.shields.io/codecov/c/gh/ParagonIaC/terraform-provider-activedirectory?style=flat-square)](https://codecov.io/gh/ParagonIaC/terraform-provider-activedirectory)
 [![GitHub license](https://img.shields.io/github/license/ParagonIaC/terraform-provider-activedirectory.svg?style=flat-square)](https://github.com/ParagonIaC/terraform-provider-activedirectory/blob/master/LICENSE)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Terraform Provider - Active Directory
 
-[![Go Report Card](https://goreportcard.com/badge/github.com/ParagonIaC/terraform-provider-activedirectory)](https://goreportcard.com/report/github.com/ParagonIaC/terraform-provider-activedirectory)
-https://goreportcard.com/report/github.com/ParagonIaC/terraform-provider-activedirectory
+[![Go Report Card](https://goreportcard.com/badge/github.com/ParagonIaC/terraform-provider-activedirectory?style=flat-square&label=building)](https://goreportcard.com/report/github.com/ParagonIaC/terraform-provider-activedirectory)
 [![CircleCI](https://img.shields.io/circleci/build/github/ParagonIaC/terraform-provider-activedirectory?style=flat-square&label=building)](https://circleci.com/gh/ParagonIaC/terraform-provider-activedirectory)
 [![Codecov](https://img.shields.io/codecov/c/gh/ParagonIaC/terraform-provider-activedirectory?style=flat-square)](https://codecov.io/gh/ParagonIaC/terraform-provider-activedirectory)
 [![GitHub license](https://img.shields.io/github/license/ParagonIaC/terraform-provider-activedirectory.svg?style=flat-square)](https://github.com/ParagonIaC/terraform-provider-activedirectory/blob/master/LICENSE)

--- a/activedirectory/base.go
+++ b/activedirectory/base.go
@@ -73,7 +73,7 @@ func (api *API) connect() error {
 
 	if api.useTLS {
 		log.Info("Configuring client to use secure connection.")
-		if err = client.StartTLS(&tls.Config{InsecureSkipVerify: api.insecure, ServerName: api.host}); err != nil {
+		if err = client.StartTLS(&tls.Config{InsecureSkipVerify: api.insecure, ServerName: api.host}); err != nil { //nolint:gosec
 			return fmt.Errorf("connect - failed to use secure connection: %s", err)
 		}
 	}

--- a/activedirectory/base.go
+++ b/activedirectory/base.go
@@ -44,6 +44,7 @@ type API struct {
 	port     int
 	domain   string
 	useTLS   bool
+	insecure bool
 	user     string
 	password string
 	client   ldap.Client
@@ -72,7 +73,7 @@ func (api *API) connect() error {
 
 	if api.useTLS {
 		log.Info("Configuring client to use secure connection.")
-		if err = client.StartTLS(&tls.Config{InsecureSkipVerify: false}); err != nil {
+		if err = client.StartTLS(&tls.Config{InsecureSkipVerify: api.insecure, ServerName: api.host}); err != nil {
 			return fmt.Errorf("connect - failed to use secure connection: %s", err)
 		}
 	}

--- a/activedirectory/provider.go
+++ b/activedirectory/provider.go
@@ -36,6 +36,12 @@ func Provider() terraform.ResourceProvider {
 				DefaultFunc: schema.EnvDefaultFunc("AD_USE_TLS", true),
 				Description: "Use TLS to secure the connection (default: true).",
 			},
+			"no_cert_verify": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("AD_NO_CERT_VERIFY", true),
+				Description: "Do not verify TLS certificate (default: true).",
+			},
 			"user": {
 				Type:        schema.TypeString,
 				Required:    true,
@@ -66,6 +72,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		port:     d.Get("port").(int),
 		domain:   d.Get("domain").(string),
 		useTLS:   d.Get("use_tls").(bool),
+		insecure: d.Get("no_cert_verify").(bool),
 		user:     d.Get("user").(string),
 		password: d.Get("password").(string),
 	}

--- a/activedirectory/provider.go
+++ b/activedirectory/provider.go
@@ -39,8 +39,8 @@ func Provider() terraform.ResourceProvider {
 			"no_cert_verify": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("AD_NO_CERT_VERIFY", true),
-				Description: "Do not verify TLS certificate (default: true).",
+				DefaultFunc: schema.EnvDefaultFunc("AD_NO_CERT_VERIFY", false),
+				Description: "Do not verify TLS certificate (default: false).",
 			},
 			"user": {
 				Type:        schema.TypeString,


### PR DESCRIPTION
Connection failed when TLS was enabled since no server name was defined and InsecureSkipVerify was set to true. We are now setting to server name in the TLS config and also allowing InsecureSkipVerify to be set to false via provider setup, which results in a TLS connection without checking the certificate.

Should solve #19 