### PR TITLE
Deal with empty computer description

### DIFF
--- a/activedirectory/computer.go
+++ b/activedirectory/computer.go
@@ -75,7 +75,9 @@ func (api *API) createComputer(cn, ou, description string) error {
 	attributes["name"] = []string{cn}
 	attributes["sAMAccountName"] = []string{cn + "$"}
 	attributes["userAccountControl"] = []string{"4096"}
-	attributes["description"] = []string{description}
+	if len(description) > 0 {
+		attributes["description"] = []string{description}
+	}
 
 	return api.createObject(fmt.Sprintf("cn=%s,%s", cn, ou), []string{"computer"}, attributes)
 }

--- a/activedirectory/computer.go
+++ b/activedirectory/computer.go
@@ -39,10 +39,16 @@ func (api *API) getComputer(name string) (*Computer, error) {
 		return nil, fmt.Errorf("getComputer - more than one computer object with the same name found")
 	}
 
+	// defaults description to empty string if not present
+	computerDescription := ""
+	if len(ret[0].attributes["description"]) > 0 {
+		computerDescription = ret[0].attributes["description"][0]
+	}
+
 	return &Computer{
 		name:        ret[0].attributes["cn"][0],
 		dn:          ret[0].dn,
-		description: ret[0].attributes["description"][0],
+		description: computerDescription,
 	}, nil
 }
 

--- a/activedirectory/computer.go
+++ b/activedirectory/computer.go
@@ -117,9 +117,15 @@ func (api *API) updateComputerOU(cn, ou, newOU string) error {
 // updates the description of an existing computer object
 func (api *API) updateComputerDescription(cn, ou, description string) error {
 	log.Infof("Updating description of computer object %s", cn)
-	return api.updateObject(fmt.Sprintf("cn=%s,%s", cn, ou), nil, nil, map[string][]string{
-		"description": {description},
-	}, nil)
+	if len(description) > 0 {
+		return api.updateObject(fmt.Sprintf("cn=%s,%s", cn, ou), nil, nil, map[string][]string{
+			"description": {description},
+		}, nil)
+	} else {
+		return api.updateObject(fmt.Sprintf("cn=%s,%s", cn, ou), nil, nil, nil, map[string][]string{
+			"description": nil,
+		})
+	}
 }
 
 // deletes an existing computer object.

--- a/activedirectory/computer_test.go
+++ b/activedirectory/computer_test.go
@@ -66,6 +66,20 @@ func TestGetComputer(t *testing.T) { // nolint:funlen // Test function
 		assert.IsType(t, &Computer{}, computer)
 	})
 
+	t.Run("getComputer - should return a computer object even without description", func(t *testing.T) {
+		cnAttribute := []string{"cn"}
+		mockClient := new(MockClient)
+		mockClient.On("Search", mock.Anything).Return(createADResult(1, cnAttribute), nil)
+
+		api := &API{client: mockClient}
+
+		computer, err := api.getComputer("")
+
+		assert.NoError(t, err)
+		assert.NotNil(t, computer)
+		assert.IsType(t, &Computer{}, computer)
+	})
+
 	t.Run("getComputer - should include 'cn' and 'description'", func(t *testing.T) {
 		matchFunc := func(sr *ldap.SearchRequest) bool {
 			return contains(sr.Attributes, "cn") &&


### PR DESCRIPTION
I'm proposing this set of changes related to computer objects with empty description. Currently I've found the following issues:

- provider crash upon reading a computer object from AD with empty description
- LDAP error when creating or modifying a computer object with empty description

Probably the same applies for ou resources, but I've not checked.

Thanks 😃 